### PR TITLE
Replace notification groups by builder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ prepareKotlinBuildScriptModel.dependsOn generateBuildConfig
 
 static def getVerifiableVersions() {
     // FIXME: Re-enable PyCharm checks.
-    def versions = ["IC-193.5662.53", /*"PC-193.5233.109" */]
+    def versions = ["IC-203.6682.168", /*"PC-203.6682.168" */]
 
     // Get the list of all versions.
     def versionUrl = new URL("https://data.services.jetbrains.com/products?code=IIC%2CPCC&fields=code%2Creleases.build%2Creleases.type")
@@ -83,9 +83,9 @@ static def getVerifiableVersions() {
 intellij {
     downloadSources.set(false)
     pluginName.set('dodona')
-    plugins.set(['java', 'PythonCore:193.5233.102'])
+    plugins.set(['java', 'PythonCore:203.6682.168'])
     updateSinceUntilBuild.set(false)
-    version.set('193.5233.102')
+    version.set('203.6682.168')
 }
 
 jacocoTestReport {
@@ -100,13 +100,14 @@ jacocoTestReport {
 patchPluginXml {
     changeNotes = """
       <ul>
-        <li>Remove deprecated function calls to support newer versions of the JetBrains suite.</li> 
+        <li><strong>Dropped support for versions lower than 2020.3</strong></li>
+        <li>Remove deprecated function calls to support newer versions of the JetBrains suite.</li>
       </ul>
       """
 
     pluginDescription = 'Companion plugin for the Ghent University Dodona platform, which allows you to submit exercises right from your favourite JetBrains IDE. More information can be found at <a href="https://docs.dodona.be/en/guides/pycharm-plugin/">https://docs.dodona.be/en/guides/pycharm-plugin/</a>'
 
-    sinceBuild = '193.3519.25'
+    sinceBuild = '203.6682.168'
 }
 
 publishPlugin {

--- a/src/main/java/io/github/thepieterdc/dodona/plugin/notifications/impl/NotificationServiceImpl.java
+++ b/src/main/java/io/github/thepieterdc/dodona/plugin/notifications/impl/NotificationServiceImpl.java
@@ -8,8 +8,7 @@
  */
 package io.github.thepieterdc.dodona.plugin.notifications.impl;
 
-import com.intellij.notification.NotificationDisplayType;
-import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationBuilder;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.project.Project;
@@ -24,11 +23,7 @@ import javax.swing.*;
  */
 public class NotificationServiceImpl implements NotificationService {
 	@NonNls
-	private static final String DODONA_NOTIFICATIONS = "Dodona Notifications";
-	
-	private static final NotificationGroup GROUP = new NotificationGroup(
-		DODONA_NOTIFICATIONS, NotificationDisplayType.BALLOON, true
-	);
+	private static final String GROUP_ID = "Dodona Notifications";
 	
 	private final Project project;
 	
@@ -69,10 +64,11 @@ public class NotificationServiceImpl implements NotificationService {
 	                    @Nullable final Icon icon,
 	                    final String title,
 	                    final String message) {
-		GROUP
-			.createNotification(title, message, type, NotificationListener.URL_OPENING_LISTENER)
+		// Get the group.
+		new NotificationBuilder(GROUP_ID, title, message, type)
 			.setIcon(icon)
-			.notify(this.project);
+			.setListener(NotificationListener.URL_OPENING_LISTENER)
+			.buildAndNotify(this.project);
 	}
 	
 	@Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,7 @@
                         serviceImplementation="io.github.thepieterdc.dodona.plugin.exercise.naming.impl.ExerciseNamingServiceImpl"/>
 
     <!-- Notifications -->
+    <notificationGroup displayType="BALLOON" id="Dodona Notifications" />
     <projectService serviceInterface="io.github.thepieterdc.dodona.plugin.notifications.NotificationService"
                     serviceImplementation="io.github.thepieterdc.dodona.plugin.notifications.impl.NotificationServiceImpl"/>
 
@@ -53,7 +54,9 @@
     <projectService serviceImplementation="io.github.thepieterdc.dodona.plugin.settings.DodonaProjectSettings"/>
 
     <!-- ToolWindow -->
-    <toolWindow anchor="right" canCloseContents="true" factoryClass="io.github.thepieterdc.dodona.plugin.toolwindow.DodonaToolWindowFactory" icon="/icons/toolwindow/icon.png" id="Dodona" secondary="true" />
+    <toolWindow anchor="right" canCloseContents="true"
+                factoryClass="io.github.thepieterdc.dodona.plugin.toolwindow.DodonaToolWindowFactory"
+                icon="/icons/toolwindow/icon.png" id="Dodona" secondary="true" />
   </extensions>
 
   <projectListeners>


### PR DESCRIPTION
Notification groups have been deprecated and scheduled for removal in IntelliJ 2022.1 and above. This PR makes that future proof.