### PR TITLE
Remove usage of course color from the plugin

### DIFF
--- a/src/main/java/io/github/thepieterdc/dodona/plugin/ui/Icons.java
+++ b/src/main/java/io/github/thepieterdc/dodona/plugin/ui/Icons.java
@@ -11,7 +11,6 @@ package io.github.thepieterdc.dodona.plugin.ui;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.util.IconUtil;
 import com.intellij.util.ui.AnimatedIcon;
-import io.github.thepieterdc.dodona.data.CourseColor;
 import org.jetbrains.annotations.NonNls;
 
 import javax.annotation.Nonnull;
@@ -71,17 +70,6 @@ public enum Icons implements Icon {
 	@Nonnull
 	public Icon color(final Color colour) {
 		return IconUtil.colorize(this.icon, colour);
-	}
-	
-	/**
-	 * Colors the icon in the given colour.
-	 *
-	 * @param colour the colour
-	 * @return the colored icon
-	 */
-	@Nonnull
-	public Icon color(final CourseColor colour) {
-		return this.color(colour.getColor());
 	}
 	
 	/**

--- a/src/main/java/io/github/thepieterdc/dodona/plugin/ui/resources/course/CourseListCellRenderer.java
+++ b/src/main/java/io/github/thepieterdc/dodona/plugin/ui/resources/course/CourseListCellRenderer.java
@@ -50,9 +50,6 @@ final class CourseListCellRenderer extends IconListCellRenderer<Course> {
 	protected void renderValue(final Course course,
 	                           final Color primary,
 	                           final Color secondary) {
-		// Set the circle.
-		this.icon.setIcon(Icons.CIRCLE.color(course.getColor()));
-		
 		// Set the name field.
 		this.name.setForeground(primary);
 		this.name.setText(course.getName());

--- a/src/main/java/io/github/thepieterdc/dodona/plugin/ui/resources/course/CourseNameRenderer.java
+++ b/src/main/java/io/github/thepieterdc/dodona/plugin/ui/resources/course/CourseNameRenderer.java
@@ -32,7 +32,6 @@ final class CourseNameRenderer extends ColoredListCellRenderer<Course> {
 	                                     final boolean b1) {
 		if (course != null) {
 			this.append(String.format(cellText, course.getYear(), course.getName()));
-			this.setIcon(Icons.CIRCLE.color(course.getColor()));
 		}
 	}
 }


### PR DESCRIPTION
this pr removes the course color icons from the plugin.

The course color has been deprecated for years and is from the dodona for the last months.

Closes https://github.com/thepieterdc/dodona-plugin-jetbrains/issues/297